### PR TITLE
Build files for deconst/Nexus and edits

### DIFF
--- a/_deconst.json
+++ b/_deconst.json
@@ -1,0 +1,3 @@
+{
+  "contentIDBase": "https://github.com/rackerlabs/rs-heat-docs/"
+}

--- a/_toc.rst
+++ b/_toc.rst
@@ -1,15 +1,16 @@
-* :ref:`overview`
+.. toctree::
+   :includehidden:
+   :maxdepth: 99
 
-  * :ref:`bootstrapping-software-config`
-  * :ref:`generic software-config`
-  * :ref:`swift-signal-handle`
-
-* Creating Orchestation templates
-
-  * :ref:`cloud-server`
-  * :ref:`cloud-loadbalancer`
-  * :ref:`cloud-monitoring`
-  * :ref:`cloud-backup`
-  * :ref:`cloud-database`
-  * :ref:`autoscale-heat-event-schedule-based`
-  * :ref:`ansible/using-ansible-with-heat`
+   bootstrapping-software-config
+   generic-software-config
+   cloud-files-cdn
+   swift-signal-handle
+   cloud-server
+   securitygroup-attachment
+   cloud-loadbalancer
+   cloud-monitoring
+   cloud-backup
+   cloud-database
+   autoscale-heat-event-schedule-based
+   ansible/using-ansible-with-heat

--- a/_toc.rst
+++ b/_toc.rst
@@ -4,7 +4,7 @@
   * :ref:`generic software-config`
   * :ref:`swift-signal-handle`
 
-* Using Orchestation
+* Creating Orchestation templates
 
   * :ref:`cloud-server`
   * :ref:`cloud-loadbalancer`

--- a/_toc.rst
+++ b/_toc.rst
@@ -1,16 +1,15 @@
-.. toctree::
-   :includehidden:
-   :maxdepth: 99
-   
-   bootstrapping-software-config
-   generic-software-config
-   cloud-files-cdn
-   swift-signal-handle
-   cloud-server
-   securitygroup-attachment
-   cloud-loadbalancer
-   cloud-monitoring
-   cloud-backup
-   cloud-database
-   autoscale-heat-event-schedule-based
-   ansible/using-ansible-with-heat
+* :ref:`overview`
+
+  * :ref:`bootstrapping-software-config`
+  * :ref:`generic software-config`
+  * :ref:`swift-signal-handle`
+
+* Using Orchestation
+
+  * :ref:`cloud-server`
+  * :ref:`cloud-loadbalancer`
+  * :ref:`cloud-monitoring`
+  * :ref:`cloud-backup`
+  * :ref:`cloud-database`
+  * :ref:`autoscale-heat-event-schedule-based`
+  * :ref:`ansible/using-ansible-with-heat`

--- a/ansible/using-ansible-with-heat.rst
+++ b/ansible/using-ansible-with-heat.rst
@@ -19,7 +19,7 @@ Pre-reading
   you can focus on how we use Heat to integrate with Ansible rather than using Ansible
   itself.
 
-Following Along
+Following along
 ===============
 
 You will probably want to clone this repository in order to easily follow along. Once
@@ -29,7 +29,7 @@ Otherwise, you may need to modify some of the commands to point to the correct l
 of various templates and/or environments. Full templates can always be found in the
 ``templates`` directory.
 
-Basic Template
+Basic template
 ==============
 
 As with all Heat templates, we start with the basic version and description sections:
@@ -150,7 +150,7 @@ outputs tell you what each represents.
       value:
         get_attr: [ server_pw, value ]
 
-Deploy the Basic Template
+Deploy the basic template
 =========================
 
 Before you deploy, you'll need to have created an image that already has the needed
@@ -161,20 +161,20 @@ template.
 
 To deploy this template, simply issue the standard command:
 
-.. code:: example
+.. code::
 
   heat stack-create -f templates/software_config_ansible.yaml -P "image=Ubuntu 14.04 LTS (HEAT)" my_nginx_simple
 
 Once the stack is ``CREATE_COMPLETE``, you can visit your new Nginx homepage by checking
 the stack output for the ip and entering that into your web browser:
 
-.. code:: example
+.. code::
 
   heat output-show my_nginx_simple server_ip
   
 You can also check the results of the playbook by checking the other outputs:
 
-.. code:: example
+.. code::
 
   heat output-show my_nginx_simple status_code  # Ansible return code
   heat output-show my_nginx_simple stdout       # Ansible output
@@ -189,7 +189,7 @@ template a bit, so lets make a copy and call it "software_config_ansible_role.ya
 
 The role and its components can be found in this repository under the ``roles`` directory.
 
-New Resources
+New resources
 -------------
 
 We'll add two new resources to pull down the role we want to use and put it in a place
@@ -224,7 +224,7 @@ We'll also deploy that script to the server:
       server:
         get_resource: server
 
-Modify Playbook
+Modify playbook
 ---------------
 
 Since we're using roles to do all of the heavy lifting, we'll modify our ``nginx_config``
@@ -259,7 +259,7 @@ resource since we'll need the role installed before we can apply it:
       server:
         get_resource: server
 
-Modify Outputs
+Modify outputs
 --------------
 
 Our script for pulling the role definition isn't terribly sophisticated. We aren't
@@ -273,18 +273,18 @@ that to the ``outputs`` section so we can check it if we need to:
     value:
       get_attr: [ deploy_role, deploy_status_code ]
 
-Deploy the Advanced Template
+Deploy the advanced template
 ============================
 
 Deploying the new template is the same as above, we just change the template name:
 
-.. code:: example
+.. code::
 
   heat stack-create -f templates/software_config_ansible_role.yaml -P "image=Ubuntu 14.04 LTS (HEAT)" my_nginx_role
 
 We can also check outputs the same way by simply changing the stack name:
 
-.. code:: example
+.. code::
 
   heat output-show my_nginx_role status_code      # Ansible return code
   heat output-show my_nginx_role stdout           # Ansible output

--- a/ansible/using-ansible-with-heat.rst
+++ b/ansible/using-ansible-with-heat.rst
@@ -11,8 +11,7 @@ bootstrap an instance with a fully configured Nginx server.
 Pre-reading
 ===========
 
-- You should prepare a bootstrapped image according to the `Bootstrapping Software Config
-  <../boostrapping_software_config.rst>`_ tutorial as we will be making use of the image
+- You should prepare a bootstrapped image according to the `Bootstrapping Software Config <../boostrapping_software_config.rst>`_ tutorial as we will be making use of the image
   pre-configured with all the required agents for software config
 - This tutorial borrows heavily from `An Ansible Tutorial <https://serversforhackers.com/an-ansible-tutorial>`_.
   Reading this guide will give you a good idea of what we'll be installing/configuring so

--- a/bootstrapping-software-config.rst
+++ b/bootstrapping-software-config.rst
@@ -28,7 +28,7 @@ basic understanding of Heat template composition and Environments.
 - `Environments Guide
   <http://docs.openstack.org/developer/heat/template_guide/environment.html>`_
 
-Following Along
+Following along
 ===============
 You will probably want to clone this repository in order to easily follow along.
 Otherwise, you may need to modify some of the commands to point to the correct locations
@@ -137,14 +137,14 @@ Your template should now look like:
       description: Root password to the server
 
 The `Heat::InstallConfigAgent` Resource
-=====================================
+=======================================
 
 You will notice that this resource has no real properties or other configuration. That's
 because we use the Environment and Template Resource features of Heat so that we can
 create several bootstrap configurations and use them for different base images as
 required.
 
-The Configuration Template
+The configuration template
 --------------------------
 
 First, lets look at the template that we'll use to provide the underlying definition for
@@ -164,7 +164,7 @@ of your application architecture. Having said that, we won't talk at all about b
 things like descriptions or versions but rather go over the resources and how they
 prepare the instance for use with Heat Software Config.
 
-Install the Basics
+Install the basics
 ++++++++++++++++++
 
 The first resource is the most complex and uses cloud-init to lay down the needed
@@ -232,7 +232,7 @@ that bootstrap the generic OpenStack agents.
         - cat /etc/os-collect-config.conf
         - os-collect-config --one-time --debug
 
-Install the Generic Agents
+Install the generic agents
 ++++++++++++++++++++++++++
 
 The actual generic OpenStack agents are installed using Python pip since there aren't any
@@ -249,7 +249,7 @@ reliable packages for them on Ubuntu.
         set -eux
         pip install os-collect-config os-apply-config os-refresh-config dib-utils
 
-Configure the Agents Service
+Configure the agents service
 ++++++++++++++++++++++++++++
 
 Next, we declare a config resource to create the service configuration (upstart or
@@ -312,7 +312,7 @@ systemd) that will start the collection agent and ensure that it runs on boot:
             exit 1
         fi
 
-Combine and expose the Configs
+Combine and expose the configs
 ++++++++++++++++++++++++++++++
 
 Finally, the configurations are all combined into a single multi-part-mime so that they 
@@ -334,7 +334,7 @@ can be output as a single file for use in user-data:
     config:
       value: { get_resource: install_config_agent }
 
-The Environment File
+The environment file
 --------------------
 
 The environment file that we'll send as part of our `stack-create` call is quite simple:
@@ -354,12 +354,12 @@ the resource namespace `Heat::InstallConfigAgent` to the template resource we cr
 the previous section. If you've used another file name or want to use the one included in
 this repository, be sure to change this mapping to point to the appropriate location.
 
-Deploy the Bootstrapped Instance
+Deploy the bootstrapped instance
 ================================
 
 All that's left to do is deploy the template:
 
-.. code:: example
+.. code::
 
   heat stack-create -f templates/software_config_custom_image.yaml -e templates/bootconfig.all.env.yaml sw_config_base
 
@@ -375,20 +375,20 @@ the next section anyway.
 Custom Image
 ============
 
-Remove Cloud-Init Artifacts
+Remove cloud-init artifacts
 ---------------------------
 
 In order for cloud-init to run on machines booted from our new image, we'll need to
 remove some artifacts from the current vm left over from our initial bootstrapping. First,
 retrieve the root password from the stack:
 
-.. code:: example
+.. code::
 
   heat output-show sw_config_base admin_password
 
 Now, log into the server via ssh by issuing the following command:
 
-.. code:: example
+.. code::
 
   ssh root@$(heat output-show sw_config_base server_ip)
 
@@ -404,7 +404,7 @@ cloud-init when it bootstrapped this server:
 - :bash:`rm /var/log/cloud-init.log`
 - :bash:`rm /var/log/cloud-init-output.log`
 
-Snapshot Your Bootstrapped Server
+Snapshot your bootstrapped server
 ---------------------------------
 
 Now we can create an image of our server. First, log into the Reach control panel and
@@ -414,7 +414,7 @@ Under the `Actions` button, select `Create an Image` and name it "Ubuntu 14.04 L
 
 Once this process is complete, you're all done!
 
-Using Your New Image
+Using your new image
 --------------------
 
 We will make use of this new image in our future tutorials on using Heat software config,

--- a/conf.py
+++ b/conf.py
@@ -45,7 +45,7 @@ source_suffix = '.rst'
 #source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = '_toc'
 
 # General information about the project.
 project = u'Rackspace Cloud Orchestration Guide'
@@ -110,7 +110,7 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/conf.py
+++ b/conf.py
@@ -45,7 +45,7 @@ source_suffix = '.rst'
 #source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = '_toc'
+master_doc = 'index'
 
 # General information about the project.
 project = u'Rackspace Cloud Orchestration Guide'
@@ -110,7 +110,7 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'classic'
+#html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -139,7 +139,7 @@ html_theme = 'classic'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/customizing-template-for-rackconnectv3.rst
+++ b/customizing-template-for-rackconnectv3.rst
@@ -27,7 +27,7 @@ Customizing a template
 repository must be accessible to public without any authentication
 
 2. Template repository may have multiple template files(Template can have multiple child templates). Find
-all the template files ending with *.yaml (except rackspace.yaml)
+all the template files ending with .yaml (except rackspace.yaml)
 
 3. In the template files, find all the places where 'OS::Nova::Server' resource is being used and provide servicenet
 and rackconnect networks to that server resource

--- a/customizing-template-for-rackconnectv3.rst
+++ b/customizing-template-for-rackconnectv3.rst
@@ -1,6 +1,6 @@
-========================
- Customizing Rackspace supported templates for Rackconnect V3 customers
-========================
+======================================================================
+Customizing Rackspace supported templates for Rackconnect V3 customers
+======================================================================
 
 Note: This document assumes that the reader is familiar with HOT
 specification. If that is not the case, please go to 'References'
@@ -9,19 +9,19 @@ section given at the end of this document for HOT specification link.
 Brief summary
 =============
 
-`Rackspace supported tempaltes <https://github.com/rackspace-orchestration-templates>`__
+`Rackspace supported templates <https://github.com/rackspace-orchestration-templates>`__
 are not currently supported for Rackconnect V3 customers. This document outlines the steps needed to
 make a template work in Rackconnected V3 account.
 
 Prerequisite
-===========================
+============
 Some of the rackspace supported templates use ChefSolo resource. If you are customizing
 a template that cotains ChefSolo resource, make sure that rack connected servers can access the internet.
 This is required because ChefSolo resource downloads chef from internet. Please contact the Rackconnect customer service
 to update outbound NAT for your rackconnect account.
 
 Customizing a template
-===========================
+======================
 
 1. Clone the template repository you wanted to customize into your public personal github account. This
 repository must be accessible to public without any authentication
@@ -51,7 +51,7 @@ server instead of public IP
 server, then use rackconnected IP instead of servicenet or public IP.
 
 Example (customized template)
-===========================
+=============================
 For example consider customizing mongodb template.
 
 1. Rackspace supported mongodb template which doesn't work for Rackconnect V3 customers is available

--- a/generic-software-config.rst
+++ b/generic-software-config.rst
@@ -289,7 +289,7 @@ config agent on Ubuntu 14.04.
 
 First, clone the heat-templates repository:
 
-.. code:: example
+.. code::
 
     git clone https://github.com/openstack/heat-templates.git
 
@@ -302,20 +302,20 @@ repository in case you want to use Fedora.
 Then, issue the stack-create command with the template and environment
 file just created using python-heatclient:
 
-.. code:: example
+.. code::
 
     heat --heat-url=https://dfw.orchestration.api.rackspacecloud.com/v1/$RS_ACCOUNT_NUMBER --os-username $RS_USER_NAME --os-password $RS_PASSWORD --os-tenant-id $RS_ACCOUNT_NUMBER --os-auth-url https://identity.api.rackspacecloud.com/v2.0/ stack-create -f generic-software-config.yaml -e heat-templates/hot/software-config/boot-config/ubuntu_pip_env.yaml generic-software-config1
 
 Next, we will edit the template and perform a stack-update. Edit the
 SoftwareDeployment parameters in the template:
 
-.. code:: example
+.. code::
 
     sed -i.bak -e 's/fooooo/fooooo1/' -e 's/baaaaa/baaaaa1/' generic-software-config.yaml 
 
 Issue the stack-update command:
 
-.. code:: example
+.. code::
 
     heat --heat-url=https://dfw.orchestration.api.rackspacecloud.com/v1/$RS_ACCOUNT_NUMBER --os-username $RS_USER_NAME --os-password $RS_PASSWORD --os-tenant-id $RS_ACCOUNT_NUMBER --os-auth-url https://identity.api.rackspacecloud.com/v2.0/ stack-update -f generic-software-config.yaml -e heat-templates/hot/software-config/boot-config/ubuntu_pip_env.yaml generic-software-config1
 

--- a/index.rst
+++ b/index.rst
@@ -6,13 +6,23 @@
 Welcome to the Rackspace Cloud Orchestration User Guide
 =======================================================
 
+This guide provides examples of writing Orchstration
+templates for the Rackspace Cloud Orchestration service,
+built on OpenStack's heat project.
+
+Read more about bootstrapping software configuration,
+such as using Ansible, as well as information about
+interacting with Rackspace Cloud services that have
+resources provided through Orchstration templates.
+
 Contents:
 
-.. toctree::
-   :maxdepth: 1
+.. toctree:: :hidden:
+   :maxdepth: 2
 
    bootstrapping-software-config
    generic-software-config
+   customizing-template-for-rackconnectv3
    cloud-files-cdn
    swift-signal-handle
    cloud-server
@@ -20,14 +30,9 @@ Contents:
    cloud-loadbalancer
    cloud-monitoring
    cloud-backup
+   cloud-bigdata
    cloud-database
    autoscale-heat-event-schedule-based
    ansible/using-ansible-with-heat
- 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   shared-ip
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Used by Travis to submit content to Nexus production
+
+set -euo pipefail
+
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
+  echo "Submitting content to production."
+  export CONTENT_STORE_URL=https://developer.rackspace.com:9000/
+  export CONTENT_STORE_APIKEY=${PROD1}${PROD2}${PROD3}
+else
+  echo "Not submitting ${TRAVIS_BRANCH} anywhere."
+fi
+
+deconst-preparer-sphinx

--- a/securitygroup-attachment.rst
+++ b/securitygroup-attachment.rst
@@ -1,6 +1,6 @@
-===================================
+==========================================
  SecurityGroup and SecurityGroupAttachment
-===================================
+==========================================
 
 Brief summary
 =============
@@ -16,7 +16,7 @@ security group to port as part of a template
 
 
 Limitations / Known Issues
-===========================
+==========================
 
 (1) In Rackspace cloud you cannot apply security groups to a port at boot time.
 
@@ -67,7 +67,7 @@ This creates a server with given image and flavor and also by default attaches p
 service net to the server instance created.
 
 Add SecurityGroup resource
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A security group is a named container for security group rules, which provide
 Rackspace Public Cloud users the ability to specify the types of traffic that
@@ -93,7 +93,7 @@ a Cloud server instance.
 Here adding a rule for SSH traffic to the security group.
 
 Add SecurityGroupAttachment resource
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now attach security group to public network port of the server instance.
 


### PR DESCRIPTION
Here's a series of commits that will enable you to build with deconst with a user guide template. I've tested locally and it looks like these screenshots. With edits, a better landing page, and PR for the nexus-control repo (which I can do) you can start publishing to developer.rackspace.com. See what you think.
<img width="450" alt="rs-heat-docs-landing" src="https://cloud.githubusercontent.com/assets/501981/10556002/78434934-743e-11e5-825e-509479ab965d.png">
<img width="450" alt="screenshot_modifyserver" src="https://cloud.githubusercontent.com/assets/501981/10556005/7ac2b852-743e-11e5-8950-f7cc8f69b3f5.png">
