### PR TITLE
Changing content depth setting to include only H1 and H2

### DIFF
--- a/_toc.rst
+++ b/_toc.rst
@@ -1,6 +1,6 @@
 .. toctree::
    :includehidden:
-   :maxdepth: 99
+   :maxdepth: 2
   
    generic-software-config
    bootstrapping-software-config


### PR DESCRIPTION
I made this change and built it with the local deconst client.  Result:  Only H1 and H2 headers show up on the navigation so readers don't have to scroll in the contents as much. 
