### PR TITLE
Adding User Guide title to top of navigation

### DIFF
--- a/_toc.rst
+++ b/_toc.rst
@@ -1,7 +1,8 @@
 .. toctree::
    :includehidden:
    :maxdepth: 2
-  
+
+   Orchestration Templates User Guide <self>
    generic-software-config
    bootstrapping-software-config
    customizing-template-for-rackconnectv3


### PR DESCRIPTION
By default, the landing page title (Rackspacee Cloud Orchestration Templates User Guide) is not included in the navigation.  Added it to top of navigation because the User Guide title is not visible after you move past the landing page. 
